### PR TITLE
Removed indexing error message

### DIFF
--- a/src/Magma.NetMap/NetMapTransmitRing.cs
+++ b/src/Magma.NetMap/NetMapTransmitRing.cs
@@ -54,8 +54,7 @@ namespace Magma.NetMap
 
         public void SendBuffer(ReadOnlyMemory<byte> buffer)
         {
-            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager, out var start, out var length)
-                || start != 0)
+            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager, out var start, out var length))
             {
                 ExceptionHelper.ThrowInvalidOperation("Invalid buffer used for sendbuffer");
             }


### PR DESCRIPTION
Now there is only an error on TryGetMemoryManager if it is a "foreign" buffer.... all good other than that