### PR TITLE
Added extra ring checks for Memory

### DIFF
--- a/samples/Magma.NetMap.Host/Program.cs
+++ b/samples/Magma.NetMap.Host/Program.cs
@@ -98,7 +98,14 @@ namespace Magma.NetMap.Host
             netmap.PrintPortInfo();
 
             Console.WriteLine("Started reading");
-            Console.ReadLine();
+            while (true)
+            {
+                var line = Console.ReadLine();
+                if (line == "x") return;
+                if (!netmap.TransmitRings[0].TryGetNextBuffer(out var buffer)) throw new Exception("Failed to get buffer");
+                netmap.TransmitRings[0].SendBuffer(buffer);
+                Console.WriteLine("Sent buffer!");
+            }
         }
     }
 }

--- a/src/Magma.NetMap/NetMapOwnedMemory.cs
+++ b/src/Magma.NetMap/NetMapOwnedMemory.cs
@@ -15,7 +15,8 @@ namespace Magma.NetMap
             BufferIndex = index;
         }
 
-        public uint BufferIndex { get; }
+        internal uint BufferIndex { get; }
+        internal int RingId { get; set; }
 
         public override Memory<byte> Memory => CreateMemory(_length);
 

--- a/src/Magma.NetMap/NetMapTransmitRing.cs
+++ b/src/Magma.NetMap/NetMapTransmitRing.cs
@@ -54,9 +54,13 @@ namespace Magma.NetMap
 
         public void SendBuffer(ReadOnlyMemory<byte> buffer)
         {
-            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager))
+            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager, out var start, out var length))
             {
                 ExceptionHelper.ThrowInvalidOperation("Invalid buffer used for sendbuffer");
+            }
+            if(start != 0)
+            {
+                ExceptionHelper.ThrowInvalidOperation("Invalid start for buffer");
             }
 
             lock (_sendBufferLock)

--- a/src/Magma.NetMap/NetMapTransmitRing.cs
+++ b/src/Magma.NetMap/NetMapTransmitRing.cs
@@ -54,7 +54,7 @@ namespace Magma.NetMap
 
         public void SendBuffer(ReadOnlyMemory<byte> buffer)
         {
-            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager, out var start, out var length))
+            if (!MemoryMarshal.TryGetMemoryManager(buffer, out NetMapOwnedMemory manager))
             {
                 ExceptionHelper.ThrowInvalidOperation("Invalid buffer used for sendbuffer");
             }
@@ -65,7 +65,6 @@ namespace Magma.NetMap
                 ref var slot = ref _rxRing[newHead];
                 if (slot.buf_idx != manager.BufferIndex)
                 {
-                    RingInfo[0].flags = (ushort)(RingInfo[0].flags | (ushort)netmap_slot_flags.NS_BUF_CHANGED);
                     slot.buf_idx = manager.BufferIndex;
                     slot.flags = (ushort)(slot.flags | (ushort)netmap_slot_flags.NS_BUF_CHANGED);
                 }

--- a/src/Magma.NetMap/NetMapTransmitRing.cs
+++ b/src/Magma.NetMap/NetMapTransmitRing.cs
@@ -45,7 +45,9 @@ namespace Magma.NetMap
                     continue;
                 }
                 var slot = _rxRing[slotIndex];
-                buffer = _bufferPool.GetBuffer(slot.buf_idx).Memory;
+                var manager = _bufferPool.GetBuffer(slot.buf_idx);
+                manager.RingId = _ringId;
+                buffer = manager.Memory;
                 return true;
             }
             buffer = default;
@@ -62,6 +64,7 @@ namespace Magma.NetMap
             {
                 ExceptionHelper.ThrowInvalidOperation("Invalid start for buffer");
             }
+            if (manager.RingId != _ringId) ExceptionHelper.ThrowInvalidOperation($"Invalid ring id, expected {_ringId} actual {manager.RingId}");
 
             lock (_sendBufferLock)
             {


### PR DESCRIPTION
Currently you could get a memory from one ring and send it to another. In theory this is okay, except that you will run one ring out of space and have a chance of overrunning the head in another.

Check now in place